### PR TITLE
Fix #43 Enable rhel-push-plugin and add Red Hat registry

### DIFF
--- a/rhel-7.template
+++ b/rhel-7.template
@@ -145,11 +145,19 @@ cat << EOF > /etc/systemd/system/docker.service
 [Unit]
 Description=Docker Application Container Engine
 After=network.target rc-local.service
+Requires=rhel-push-plugin.socket
 
 [Service]
 Type=notify
 ExecStartPre=/opt/cert-gen.sh
-ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --storage-driver devicemapper --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem
+ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:2376 \
+         --authorization-plugin=rhel-push-plugin \
+         --add-registry=registry.access.redhat.com \
+         -H unix:///var/run/docker.sock \
+         --storage-driver devicemapper \
+         --tlsverify --tlscacert /etc/docker/ca.pem \
+         --tlscert /etc/docker/server.pem \
+         --tlskey /etc/docker/server-key.pem
 ExecReload=/bin/kill -s HUP
 MountFlags=slave
 LimitNOFILE=infinity
@@ -165,6 +173,7 @@ WantedBy=multi-user.target
 EOF
 
 systemctl enable docker
+systemctl enable rhel-push-plugin
 
 rm -f /etc/resolv.conf
 rm -rf /usr/lib/locale/locale-archive


### PR DESCRIPTION
This patch will enable rhel-push-plugin for docker.