### PR TITLE
(WIP) Fix #21: Create a CI setup for the image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,7 @@ check_env:
 		echo "updates_repo_url is undefined, Please check README"; \
 		exit 1; \
 	fi
+
+.PHONY: test
+test:
+	avocado run tests/test.py

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,22 @@
+import time
+import logging
+import os
+import subprocess
+
+from avocado import VERSION
+from avocado import Test
+
+class MinishiftISOTest(Test):
+
+    def setUp(self):
+        ''' Test Setup '''
+        self.test_DIR = os.path.dirname(os.path.realpath(__file__))
+        self.log.info("################################################################")
+        self.log.info("Avocado version : %s" % VERSION)
+        self.log.info("################################################################")
+
+    def test_minishift_centos_iso_file(self):
+        ''' minishift centos iso file existence test '''
+        self.log.info("Testing minishift centos iso file existence ...")
+        iso_file = "%s/../build/minishift-centos.iso" % self.test_DIR
+        self.assertTrue(os.path.isfile(iso_file))


### PR DESCRIPTION
Fix #21

Using [Avocado Framework](http://avocado-framework.readthedocs.io/) here as test runner with other benefits like versioned logging with run log saved in `<AVOCADO_DIR>/job_results/latest` folder.

#### Format for running is
```
[vagrant@localhost minishift-centos-iso]$ avocado run tests/test.py --dry-run
JOB ID     : 0000000000000000000000000000000000000000
JOB LOG    : /var/tmp/avocado-dry-run-s9D297/job-2016-12-09T09.39-0000000/job.log
TESTS      : 3
 (1/3) tests/test.py:MinishiftISOTest.test_minishift_centos_iso_build: SKIP
 (2/3) tests/test.py:MinishiftISOTest.test_minishift_centos_iso_file: SKIP
 (3/3) tests/test.py:MinishiftISOTest.test_build_cleanup: SKIP
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 3 | WARN 0 | INTERRUPT 0
TESTS TIME : 0.01 s
```

#### Sample log file 
```
[vagrant@localhost minishift-centos-iso]$ cat /home/vagrant/avocado/job-results/job-2016-12-09T09.39-5f6648b/job.log
2016-12-09 09:39:31,210 extension        L0156 DEBUG| found extension EntryPoint.parse('journal = avocado.plugins.journal:JournalResult')
2016-12-09 09:39:31,210 extension        L0156 DEBUG| found extension EntryPoint.parse('tap = avocado.plugins.tap:TAPResult')
2016-12-09 09:39:31,210 extension        L0156 DEBUG| found extension EntryPoint.parse('human = avocado.plugins.human:Human')
2016-12-09 09:39:31,215 extension        L0156 DEBUG| found extension EntryPoint.parse('jobscripts = avocado.plugins.jobscripts:JobScripts')
2016-12-09 09:39:31,216 sysinfo          L0388 INFO | Commands configured by file: /etc/avocado/sysinfo/commands
2016-12-09 09:39:31,216 sysinfo          L0399 INFO | Files configured by file: /etc/avocado/sysinfo/files
2016-12-09 09:39:31,216 sysinfo          L0419 INFO | Profilers configured by file: /etc/avocado/sysinfo/profilers
2016-12-09 09:39:31,216 sysinfo          L0427 INFO | Profiler disabled
2016-12-09 09:39:31,222 sysinfo          L0239 DEBUG| Journalctl collection failed: Command 'journalctl --quiet --lines 1 --output json' failed (rc=1)
2016-12-09 09:39:31,222 job              L0315 INFO | Command line: /usr/bin/avocado run tests/test.py
2016-12-09 09:39:31,222 job              L0316 INFO | 
2016-12-09 09:39:31,222 job              L0321 INFO | Avocado version: 44.0
2016-12-09 09:39:31,223 job              L0333 INFO | 
2016-12-09 09:39:31,223 job              L0338 INFO | Config files read (in order):
2016-12-09 09:39:31,223 job              L0340 INFO | /etc/avocado/avocado.conf
2016-12-09 09:39:31,223 job              L0340 INFO | /etc/avocado/conf.d/gdb.conf
2016-12-09 09:39:31,223 job              L0340 INFO | /home/vagrant/.config/avocado/avocado.conf
2016-12-09 09:39:31,223 job              L0345 INFO | 
2016-12-09 09:39:31,223 job              L0347 INFO | Avocado config:
2016-12-09 09:39:31,224 job              L0356 INFO | Section.Key                             Value
2016-12-09 09:39:31,224 job              L0356 INFO | datadir.paths.base_dir                  /usr/share/avocado
2016-12-09 09:39:31,224 job              L0356 INFO | datadir.paths.test_dir                  /usr/share/avocado/tests
2016-12-09 09:39:31,224 job              L0356 INFO | datadir.paths.data_dir                  /usr/share/avocado/data
2016-12-09 09:39:31,224 job              L0356 INFO | datadir.paths.logs_dir                  ~/avocado/job-results
2016-12-09 09:39:31,224 job              L0356 INFO | sysinfo.collect.enabled                 True
2016-12-09 09:39:31,224 job              L0356 INFO | sysinfo.collect.installed_packages      False
2016-12-09 09:39:31,224 job              L0356 INFO | sysinfo.collect.profiler                False
2016-12-09 09:39:31,224 job              L0356 INFO | sysinfo.collect.locale                  C
2016-12-09 09:39:31,224 job              L0356 INFO | sysinfo.collectibles.commands           /etc/avocado/sysinfo/commands
2016-12-09 09:39:31,224 job              L0356 INFO | sysinfo.collectibles.files              /etc/avocado/sysinfo/files
2016-12-09 09:39:31,224 job              L0356 INFO | sysinfo.collectibles.profilers          /etc/avocado/sysinfo/profilers
2016-12-09 09:39:31,225 job              L0356 INFO | runner.output.colored                   True
2016-12-09 09:39:31,225 job              L0356 INFO | runner.output.utf8                      
2016-12-09 09:39:31,225 job              L0356 INFO | remoter.behavior.reject_unknown_hosts   False
2016-12-09 09:39:31,225 job              L0356 INFO | remoter.behavior.disable_known_hosts    False
2016-12-09 09:39:31,225 job              L0356 INFO | job.output.loglevel                     debug
2016-12-09 09:39:31,225 job              L0356 INFO | restclient.connection.hostname          localhost
2016-12-09 09:39:31,225 job              L0356 INFO | restclient.connection.port              9405
2016-12-09 09:39:31,225 job              L0356 INFO | restclient.connection.username          
2016-12-09 09:39:31,225 job              L0356 INFO | restclient.connection.password          
2016-12-09 09:39:31,225 job              L0356 INFO | plugins.disable                         []
2016-12-09 09:39:31,225 job              L0356 INFO | plugins.skip_broken_plugin_notification []
2016-12-09 09:39:31,225 job              L0356 INFO | plugins.loaders                         ['file', '@DEFAULT']
2016-12-09 09:39:31,225 job              L0356 INFO | gdb.paths.gdb                           /usr/bin/gdb
2016-12-09 09:39:31,225 job              L0356 INFO | gdb.paths.gdbserver                     /usr/bin/gdbserver
2016-12-09 09:39:31,225 job              L0357 INFO | 
2016-12-09 09:39:31,225 job              L0362 INFO | Avocado Data Directories:
2016-12-09 09:39:31,225 job              L0363 INFO | 
2016-12-09 09:39:31,225 job              L0364 INFO | Avocado replaces config dirs that can't be accessed
2016-12-09 09:39:31,225 job              L0365 INFO | with sensible defaults. Please edit your local config
2016-12-09 09:39:31,225 job              L0366 INFO | file to customize values
2016-12-09 09:39:31,225 job              L0367 INFO | 
2016-12-09 09:39:31,226 job              L0368 INFO | base     /home/vagrant/avocado
2016-12-09 09:39:31,226 job              L0369 INFO | tests    /home/vagrant/avocado/tests
2016-12-09 09:39:31,226 job              L0370 INFO | data     /home/vagrant/avocado/data
2016-12-09 09:39:31,226 job              L0371 INFO | logs     /home/vagrant/avocado/job-results
2016-12-09 09:39:31,226 job              L0372 INFO | 
2016-12-09 09:39:31,226 job              L0386 INFO | Temporary dir: /var/tmp/avocado_mAFPyb
2016-12-09 09:39:31,226 job              L0387 INFO | 
2016-12-09 09:39:31,226 job              L0394 INFO | Variant 1:    /
2016-12-09 09:39:31,226 job              L0397 INFO | 
2016-12-09 09:39:31,227 job              L0306 INFO | Job ID: 5f6648bc792878c770a88dc8050165bccdafe3a3
2016-12-09 09:39:31,227 job              L0309 INFO | 
2016-12-09 09:39:31,235 sysinfo          L0107 DEBUG| Not logging /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor (file does not exist)
2016-12-09 09:39:31,253 sysinfo          L0107 DEBUG| Not logging /proc/pci (file does not exist)
2016-12-09 09:39:31,262 sysinfo          L0105 DEBUG| Not logging /proc/slabinfo (lack of permissions)
2016-12-09 09:39:31,266 sysinfo          L0107 DEBUG| Not logging /sys/kernel/debug/sched_features (file does not exist)
2016-12-09 09:39:31,349 sysinfo          L0388 INFO | Commands configured by file: /etc/avocado/sysinfo/commands
2016-12-09 09:39:31,349 sysinfo          L0399 INFO | Files configured by file: /etc/avocado/sysinfo/files
2016-12-09 09:39:31,349 sysinfo          L0419 INFO | Profilers configured by file: /etc/avocado/sysinfo/profilers
2016-12-09 09:39:31,349 sysinfo          L0427 INFO | Profiler disabled
2016-12-09 09:39:31,356 sysinfo          L0239 DEBUG| Journalctl collection failed: Command 'journalctl --quiet --lines 1 --output json' failed (rc=1)
2016-12-09 09:39:31,356 multiplexer      L0168 DEBUG| PARAMS (key=timeout, path=*, default=None) => None
2016-12-09 09:39:31,356 test             L0219 INFO | START 1-tests/test.py:MinishiftISOTest.test_minishift_centos_iso_file
2016-12-09 09:39:31,371 test             L0014 INFO | ################################################################
2016-12-09 09:39:31,371 test             L0015 INFO | Avocado version : 44.0
2016-12-09 09:39:31,371 test             L0016 INFO | ################################################################
2016-12-09 09:39:31,371 test             L0027 INFO | Testing minishift centos iso file existence ...
2016-12-09 09:39:31,377 sysinfo          L0341 DEBUG| Not logging /var/log/messages (lack of permissions)
2016-12-09 09:39:31,378 test             L0613 INFO | PASS 1-tests/test.py:MinishiftISOTest.test_minishift_centos_iso_file
2016-12-09 09:39:31,378 test             L0594 INFO | 
2016-12-09 09:39:31,394 sysinfo          L0388 INFO | Commands configured by file: /etc/avocado/sysinfo/commands
2016-12-09 09:39:31,395 sysinfo          L0399 INFO | Files configured by file: /etc/avocado/sysinfo/files
2016-12-09 09:39:31,395 sysinfo          L0419 INFO | Profilers configured by file: /etc/avocado/sysinfo/profilers
2016-12-09 09:39:31,395 sysinfo          L0427 INFO | Profiler disabled
2016-12-09 09:39:31,400 sysinfo          L0239 DEBUG| Journalctl collection failed: Command 'journalctl --quiet --lines 1 --output json' failed (rc=1)
2016-12-09 09:39:31,401 multiplexer      L0168 DEBUG| PARAMS (key=timeout, path=*, default=None) => None
2016-12-09 09:39:31,401 test             L0219 INFO | START 2-tests/test.py:MinishiftISOTest.test_build_cleanup
2016-12-09 09:39:31,406 test             L0014 INFO | ################################################################
2016-12-09 09:39:31,406 test             L0015 INFO | Avocado version : 44.0
2016-12-09 09:39:31,406 test             L0016 INFO | ################################################################
2016-12-09 09:39:31,406 test             L0035 INFO | Testing minishift build cleanup process ...
2016-12-09 09:39:31,478 sysinfo          L0341 DEBUG| Not logging /var/log/messages (lack of permissions)
2016-12-09 09:39:31,478 test             L0613 INFO | PASS 2-tests/test.py:MinishiftISOTest.test_build_cleanup
2016-12-09 09:39:31,478 test             L0594 INFO | 
2016-12-09 09:39:31,500 sysinfo          L0107 DEBUG| Not logging /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor (file does not exist)
2016-12-09 09:39:31,517 sysinfo          L0107 DEBUG| Not logging /proc/pci (file does not exist)
2016-12-09 09:39:31,527 sysinfo          L0105 DEBUG| Not logging /proc/slabinfo (lack of permissions)
2016-12-09 09:39:31,530 sysinfo          L0107 DEBUG| Not logging /sys/kernel/debug/sched_features (file does not exist)
2016-12-09 09:39:31,564 job              L0472 INFO | Test results available in /home/vagrant/avocado/job-results/job-2016-12-09T09.39-5f6648b
```
