### PR TITLE
Fix #53 Add release target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BUILD_DIR=$(shell pwd)/build
 HANDLE_USER_DATA=$(shell base64 -w 0 scripts/handle-user-data)
 CERT_GEN=$(shell base64 -w 0 scripts/cert-gen.sh)
+VERSION=1.0.0-alpha.1
 
 default: centos_iso
 
@@ -27,7 +28,7 @@ rhel_iso: iso_creation
 
 .PHONY: iso
 iso_creation: init
-	handle_user_data='$(HANDLE_USER_DATA)' cert_gen='$(CERT_GEN)' envsubst < $(KICKSTART_TEMPLATE) > $(BUILD_DIR)/$(KICKSTART_FILE)
+	handle_user_data='$(HANDLE_USER_DATA)' cert_gen='$(CERT_GEN)' version='$(VERSION)' envsubst < $(KICKSTART_TEMPLATE) > $(BUILD_DIR)/$(KICKSTART_FILE)
 	cd $(BUILD_DIR); sudo livecd-creator --config $(BUILD_DIR)/$(KICKSTART_FILE) --logfile=$(BUILD_DIR)/livecd-creator.log --fslabel $(ISO_NAME)
 	# http://askubuntu.com/questions/153833/why-cant-i-mount-the-ubuntu-12-04-installer-isos-in-mac-os-x
 	# http://www.syslinux.org/wiki/index.php?title=Doc/isolinux#HYBRID_CD-ROM.2FHARD_DISK_MODE
@@ -47,3 +48,16 @@ check_env:
 		echo "updates_repo_url is undefined, Please check README"; \
 		exit 1; \
 	fi
+
+.PHONY: get_gh-release
+get_gh-release: init
+	curl -sL https://github.com/progrium/gh-release/releases/download/v2.2.1/gh-release_2.2.1_linux_x86_64.tgz > $(BUILD_DIR)/gh-release_2.2.1_linux_x86_64.tgz
+	tar -xvf $(BUILD_DIR)/gh-release_2.2.1_linux_x86_64.tgz -C $(BUILD_DIR)
+	rm -fr $(BUILD_DIR)/gh-release_2.2.1_linux_x86_64.tgz
+
+.PHONY: release
+release: centos_iso get_gh-release
+	rm -rf release && mkdir -p release
+	cp $(BUILD_DIR)/minishift-centos.iso release/
+	$(BUILD_DIR)/gh-release checksums sha256
+	$(BUILD_DIR)/gh-release create minishift/minishift-centos-iso $(VERSION) master v$(VERSION)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ the boot2docker ISO.
 		- [Prerequisites](#prerequisites-1)
 		- [Building the ISO](#building-the-iso-1)
 - [Building the RHEL ISO](#building-the-rhel-iso)
+- [Releasing Minishift ISO](#releasing-minishift-iso)
 - [Further reading](#further-reading)
-
 <!-- /MarkdownTOC -->
 
 <a name="building-the-centos-iso"></a>
@@ -86,6 +86,19 @@ $ export rhel_tree_url="<rhel_tree_to_fetch_kernel>"
 $ export base_repo_url="<base_repo_url_to_install_packages>"
 $ export updates_repo_url="<updates_repo_url_to_package_updates>"
 $ make rhel_iso
+```
+
+<a name="releasing-minishift-iso"></a>
+## Releasing Minishift ISO
+
+- Assemble all the meaningful changes since the last release to create release notes.
+- Bump the `VERSION` variable in the Makefile.
+- Before you execute below command be sure to have a [Github personal access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use) defined in your environment as `GITHUB_ACCESS_TOKEN`.
+
+Run:
+
+```shell
+make release
 ```
 
 <a name="further-reading"></a>

--- a/centos-7.template
+++ b/centos-7.template
@@ -91,6 +91,7 @@ EOF
 
 # minishift as variant for custom provisioner
 echo "VARIANT=\"minishift\"" >> /etc/os-release
+echo "VARIANT_VERSION=\"${version}\"" >> /etc/os-release
 
 base64 -d < handle-user-data.base64 > handle-user-data
 mv handle-user-data /etc/rc.d/init.d/

--- a/rhel-7.template
+++ b/rhel-7.template
@@ -114,6 +114,7 @@ EOF
 
 # minishift as variant for custom provisioner
 echo "VARIANT=\"minishift\"" >> /etc/os-release
+echo "VARIANT_VERSION=\"${version}\"" >> /etc/os-release
 
 base64 -d < handle-user-data.base64 > handle-user-data
 mv handle-user-data /etc/rc.d/init.d/


### PR DESCRIPTION
This patch will enable release from make provided required token is available.
- Updated README
- Create version file
- Updated version info in templates. 