### PR TITLE
Fix #57 Error to build RHEL iso using "make rhel_iso" command.

### DIFF
--- a/rhel-7.template
+++ b/rhel-7.template
@@ -4,7 +4,7 @@ firewall --disabled
 selinux --disabled
 
 # Use network installation
-url --url= ${rhel_tree_url}
+url --url=${rhel_tree_url}
 network --bootproto=dhcp --device=link --activate --onboot=on
 skipx
 rootpw --plaintext centos


### PR DESCRIPTION
This patch will fix a typo which create issue to build rhel_iso.