### PR TITLE
Fix #65 Remove epel repo details from RHEL template

### DIFF
--- a/rhel-7.template
+++ b/rhel-7.template
@@ -97,16 +97,6 @@ TYPE="Ethernet"
 PERSISTENT_DHCLIENT="yes"
 EOF
 
-# To make sure works without subscription
-cat > /etc/yum.repos.d/epel.repo << EOF
-[epel]
-name=Extra Packages for Enterprise Linux 7 - $basearch
-mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
-enabled=1
-gpgcheck=0
-#
-EOF
-
 # Place holder for base64 encrypt handle-user-data script
 cat > handle-user-data.base64 << EOF
 ${handle_user_data}


### PR DESCRIPTION
This patch will remove epel repo details from the template which we added to test our image against docker-machine without our provisioner was in place.