### PR TITLE
Issue #76 Create minishift directory symlink to accommodate --host-data-dir option

### DIFF
--- a/scripts/handle-user-data
+++ b/scripts/handle-user-data
@@ -19,7 +19,7 @@ mount_data_partition() {
 
     # Just in case, the links will fail if not
     umount -f /var/lib/docker || true
-    rm -rf /var/lib/docker /var/lib/boot2docker /etc/docker /var/lib/origin
+    rm -rf /var/lib/docker /var/lib/boot2docker /etc/docker /var/lib/minishift
 
     # Detected a disk with a normal linux install (/var/lib/docker + more))
     if [ ! -d "/var/lib" ]; then
@@ -35,11 +35,8 @@ mount_data_partition() {
     mkdir -p /mnt/$PARTNAME/var/lib/boot2docker/etc/docker
     ln -s /mnt/$PARTNAME/var/lib/boot2docker/etc/docker /etc/docker
 
-    # Here we used bind mount because currently openshift doesn't work
-    # with symlink, refer: https://github.com/openshift/origin/issues/12029
-    mkdir -p /mnt/$PARTNAME/var/lib/origin
-    mkdir -p /var/lib/origin
-    mount --bind /mnt/$PARTNAME/var/lib/origin/ /var/lib/origin/
+    mkdir -p /mnt/$PARTNAME/var/lib/minishift
+    ln -s /mnt/$PARTNAME/var/lib/minishift /var/lib/minishift
 
     # Make sure /tmp is on the disk too
     rm -rf /mnt/$PARTNAME/tmp || true


### PR DESCRIPTION
This patch add minishift directory and symlink with persistent storage. 

Depend on: https://github.com/minishift/minishift/pull/261

Steps to test:
- Build the iso with this patch
- Get minishift binary from https://ci.appveyor.com/project/hferentschik/minishift-o61ou/build/138/artifacts
- run minishift against built images
- Create some test application on minishift or add a template
- stop minishift
- start minishift => you should have test application configuration or template persistent. 