### PR TITLE
Issue #1 Build the ISO with SELinux in enforcing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ the boot2docker ISO.
 <!-- MarkdownTOC -->
 
 - [Building the CentOS ISO](#building-the-centos-iso)
-	- [On CentOS/Fedora](#on-centosfedora)
+	- [On CentOS-7](#on-centos)
 		- [Prerequisites](#prerequisites)
 		- [Building the ISO](#building-the-iso)
-	- [On hosts without _livecd-tools_ \(OS X, Windows, ...\)](#on-hosts-without-livecd-tools-os-x-windows-)
+	- [On hosts _other than CentOS-7_ \(OS X, Windows, Fedora ...\)](#non-centos7-hosts)
 		- [Prerequisites](#prerequisites-1)
 		- [Building the ISO](#building-the-iso-1)
 - [Building the RHEL ISO](#building-the-rhel-iso)
@@ -22,22 +22,27 @@ the boot2docker ISO.
 <a name="building-the-centos-iso"></a>
 ## Building the CentOS ISO
 
-The following contains instructions on how to build the default (CentOS based) ISO.
+The following contains instructions on how to build the default (CentOS7 based) ISO.
 If you are able to install [livecd-tools](https://github.com/rhinstaller/livecd-tools)
-directly on your machine, you can use the [CentOS/Fedora](#on-centosfedora) instructions.
+directly on your machine, you can use the [CentOS](#on-centos) instructions.
 
-If you don't have _livecd-tools_, follow the
-[hosts without livecd-tools](#on-hosts-without-livecd-tools-os-x-windows-) instructions.
+If you don't have _livecd-tools or using different linux distro other than centos_, follow the
+[hosts other than CentOS-7](#non-centos7-hosts) instructions.
 
-<a name="on-centosfedora"></a>
-### On CentOS/Fedora
+<a name="on-centos"></a>
+### On CentOS
 
 <a name="prerequisites"></a>
 #### Prerequisites
+* Update your system before start and if there is kernel update then reboot your system to activate latest kernel.
 
-* [livecd-tools](https://github.com/rhinstaller/livecd-tools)
+        $ yum update -y
 
-        $ yum install -y livecd-tools
+* [Install livecd-tools](https://github.com/rhinstaller/livecd-tools)
+
+  Note: We use to have docker installed on system to get selinux context, [check bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1303565)
+
+        $ yum install -y livecd-tools docker
 
 
 <a name="building-the-iso"></a>
@@ -49,8 +54,8 @@ $ cd minishift-centos-iso
 $ make
 ```
 
-<a name="on-hosts-without-livecd-tools-os-x-windows-"></a>
-### On hosts without _livecd-tools_ (OS X, Windows, ...)
+<a name="non-centos7-hosts"></a>
+### On hosts _other than CentOS-7_ (OS X, Windows, Fedora ...)
 
 <a name="prerequisites-1"></a>
 #### Prerequisites

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "shell", inline: <<-SHELL
-    sudo yum install -y git livecd-tools
+    # Docker and parted is required to get selinux context: https://bugzilla.redhat.com/show_bug.cgi?id=1303565
+    sudo yum install -y git livecd-tools docker parted
   SHELL
 end

--- a/centos-7.template
+++ b/centos-7.template
@@ -1,7 +1,7 @@
 sshpw --username=root --plaintext centos
 # Firewall configuration
 firewall --disabled
-selinux --disabled
+selinux --enforcing
 
 # Use network installation
 url --url="http://mirror.centos.org/centos/7/os/x86_64/"
@@ -64,7 +64,6 @@ hyperv-daemons
 -iwl6050-firmware
 -iwl7260-firmware
 -iwl7265-firmware
--parted
 -postfix
 -rsyslog
 %end
@@ -129,7 +128,13 @@ After=network.target rc-local.service
 [Service]
 Type=notify
 ExecStartPre=/opt/cert-gen.sh
-ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --storage-driver devicemapper --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem
+ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:2376 \
+                       -H unix:///var/run/docker.sock \
+                       --selinux-enabled \
+                       --storage-driver devicemapper \
+                       --tlsverify --tlscacert /etc/docker/ca.pem \
+                       --tlscert /etc/docker/server.pem \
+                       --tlskey /etc/docker/server-key.pem
 ExecReload=/bin/kill -s HUP
 MountFlags=slave
 LimitNOFILE=infinity

--- a/rhel-7.template
+++ b/rhel-7.template
@@ -1,7 +1,7 @@
 sshpw --username=root --plaintext redhat
 # Firewall configuration
 firewall --disabled
-selinux --disabled
+selinux --enforcing
 
 # Use network installation
 url --url=${rhel_tree_url}
@@ -64,7 +64,6 @@ cdk-entitlements
 -iwl6050-firmware
 -iwl7260-firmware
 -iwl7265-firmware
--parted
 -postfix
 -rsyslog
 %end
@@ -150,6 +149,7 @@ Type=notify
 ExecStartPre=/opt/cert-gen.sh
 ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:2376 \
          --authorization-plugin=rhel-push-plugin \
+         --selinux-enabled \
          --add-registry=registry.access.redhat.com \
          -H unix:///var/run/docker.sock \
          --storage-driver devicemapper \


### PR DESCRIPTION
Below patch will resolve issue around SELinux enforcing mode. Please test it out before we merge it.

Make sure if you are not using centos-7 then use vagrant way of creating image I did update the document because live-tools are very specific around which host we are using for creating the images. 