### PR TITLE
Fix #85 docker-1.12.5 break docker daemon and need docker-runc-current

### DIFF
--- a/rhel-7.template
+++ b/rhel-7.template
@@ -135,6 +135,9 @@ base64 -d < cert-gen.sh.base64 > cert-gen.sh
 chmod +x cert-gen.sh
 mv cert-gen.sh /opt
 
+# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1414250
+ln -s /usr/bin/dockerd-current /usr/bin/dockerd
+
 # This unit file will take precedence over unit file which present /usr location
 # and it have daemon running using cert so when restart happen then also docker
 # daemon works as expected.
@@ -150,6 +153,8 @@ ExecStartPre=/opt/cert-gen.sh
 ExecStart=/usr/bin/docker daemon -H tcp://0.0.0.0:2376 \
          --authorization-plugin=rhel-push-plugin \
          --selinux-enabled \
+         --add-runtime docker-runc=/usr/libexec/docker/docker-runc-current \
+         --default-runtime=docker-runc \
          --add-registry=registry.access.redhat.com \
          -H unix:///var/run/docker.sock \
          --storage-driver devicemapper \


### PR DESCRIPTION
This patch will be a workaround for latest docker and also added required runc dependency to service file.