### PR TITLE
Issue #116 Show banner when installing packages using `yum`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BUILD_DIR=$(shell pwd)/build
 BIN_DIR=$(BUILD_DIR)/bin
 HANDLE_USER_DATA=$(shell base64 -w 0 scripts/handle-user-data)
+YUM_WRAPPER=$(shell base64 -w 0 scripts/yum-wrapper)
 CERT_GEN=$(shell base64 -w 0 scripts/cert-gen.sh)
 VERSION=1.0.0
 GITTAG=$(shell git rev-parse --short HEAD)
@@ -37,8 +38,9 @@ rhel_iso: iso_creation
 
 .PHONY: iso_creation
 iso_creation: init
-	@handle_user_data='$(HANDLE_USER_DATA)' cert_gen='$(CERT_GEN)' version='$(VERSION)' build_id='$(GITTAG)-$(TODAY)-$(BUILD_ID)' \
-			 envsubst < $(KICKSTART_TEMPLATE) > $(BUILD_DIR)/$(KICKSTART_FILE)
+	@handle_user_data='$(HANDLE_USER_DATA)' yum_wrapper='$(YUM_WRAPPER)' cert_gen='$(CERT_GEN)' \
+		version='$(VERSION)' build_id='$(GITTAG)-$(TODAY)-$(BUILD_ID)' \
+		envsubst < $(KICKSTART_TEMPLATE) > $(BUILD_DIR)/$(KICKSTART_FILE)
 	cd $(BUILD_DIR); sudo livecd-creator --config $(BUILD_DIR)/$(KICKSTART_FILE) --logfile=$(BUILD_DIR)/livecd-creator.log --fslabel $(ISO_NAME)
 	# http://askubuntu.com/questions/153833/why-cant-i-mount-the-ubuntu-12-04-installer-isos-in-mac-os-x
 	# http://www.syslinux.org/wiki/index.php?title=Doc/isolinux#HYBRID_CD-ROM.2FHARD_DISK_MODE

--- a/centos-7.template
+++ b/centos-7.template
@@ -84,7 +84,7 @@ echo "LANG=\"C\"" > /etc/locale.conf
 echo "%docker ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/docker
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
-# Place holder for base64 encrypt handle-user-data script
+# Place holder for base64 encode handle-user-data script
 cat > handle-user-data.base64 << EOF
 ${handle_user_data}
 EOF
@@ -95,6 +95,7 @@ echo "VARIANT_VERSION=\"${version}\"" >> /etc/os-release
 echo "BUILD_ID=\"${build_id}\"" >> /etc/os-release
 
 base64 -d < handle-user-data.base64 > handle-user-data
+rm handle-user-data.base64
 mv handle-user-data /etc/rc.d/init.d/
 
 chmod +x /etc/rc.d/init.d/handle-user-data
@@ -117,6 +118,7 @@ ${cert_gen}
 EOF
 
 base64 -d < cert-gen.sh.base64 > cert-gen.sh
+rm cert-gen.sh.base64
 chmod +x cert-gen.sh
 mv cert-gen.sh /opt
 
@@ -166,6 +168,18 @@ EOF
 
 systemctl enable docker
 
+# Show a warning banner when using yum to install software
+mv /usr/bin/yum /usr/bin/yum-unsupported
+# Place holder for base64 encode yum-wrapper script
+cat > yum-wrapper.base64 << EOF
+${yum_wrapper}
+EOF
+base64 -d < yum-wrapper.base64 > yum-wrapper
+rm yum-wrapper.base64
+mv yum-wrapper /usr/bin/yum
+chmod +x /usr/bin/yum
+
+# Clean
 rm -rf /usr/lib/locale/locale-archive
 rm -rf /var/cache/yum/*
 

--- a/rhel-7.template
+++ b/rhel-7.template
@@ -101,7 +101,7 @@ TYPE="Ethernet"
 PERSISTENT_DHCLIENT="yes"
 EOF
 
-# Place holder for base64 encrypt handle-user-data script
+# Place holder for base64 encode handle-user-data script
 cat > handle-user-data.base64 << EOF
 ${handle_user_data}
 EOF
@@ -112,6 +112,7 @@ echo "VARIANT_VERSION=\"${version}\"" >> /etc/os-release
 echo "BUILD_ID=\"${build_id}\"" >> /etc/os-release
 
 base64 -d < handle-user-data.base64 > handle-user-data
+rm handle-user-data.base64
 mv handle-user-data /etc/rc.d/init.d/
 
 chmod +x /etc/rc.d/init.d/handle-user-data
@@ -134,6 +135,7 @@ ${cert_gen}
 EOF
 
 base64 -d < cert-gen.sh.base64 > cert-gen.sh
+rm cert-gen.sh.base64
 chmod +x cert-gen.sh
 mv cert-gen.sh /opt
 
@@ -185,6 +187,17 @@ EOF
 
 systemctl enable docker
 systemctl enable rhel-push-plugin
+
+# Show a warning banner when using yum to install software
+mv /usr/bin/yum /usr/bin/yum-unsupported
+# Place holder for base64 encode yum-wrapper script
+cat > yum-wrapper.base64 << EOF
+${yum_wrapper}
+EOF
+base64 -d < yum-wrapper.base64 > yum-wrapper
+rm yum-wrapper.base64
+mv yum-wrapper /usr/bin/yum
+chmod +x /usr/bin/yum
 
 rm -f /etc/resolv.conf
 rm -rf /usr/lib/locale/locale-archive

--- a/scripts/yum-wrapper
+++ b/scripts/yum-wrapper
@@ -1,0 +1,22 @@
+#!/bin/sh
+function hr() {
+  printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
+}
+
+function banner() {
+  hr
+  echo -e "Installing additional packages on the root filesystem might exceed the allocated overlay size and lock the Minishift VM. Proceed with the installation at your own risk."
+  echo -e "For more information, see https://docs.openshift.org/latest/minishift/using/troubleshooting.html#root-filesystem-exceeds-overlay-size"
+  hr
+}
+
+banner
+if echo "$@" | grep -iq " -y" ; then
+  answer="y"
+else
+  echo "Are you sure you want to continue? [y/N]"
+  read answer
+fi
+if echo "$answer" | grep -iq "^y" ; then
+    yum-unsupported $@
+fi

--- a/tests/test.py
+++ b/tests/test.py
@@ -81,7 +81,8 @@ class MinishiftISOTest(Test):
 
     def test_swapspace(self):
         ''' Test if swap space is available on restart '''
-        cmd = self.bin_dir + "minishift start"
+        start_args = (self.driver_name, "file://"  + self.iso_file)
+        cmd = self.bin_dir + "minishift start --vm-driver %s --iso-url %s" % start_args
         self.execute_test({ 'cmd': cmd })
 
         # Check swap space


### PR DESCRIPTION
Deals with #116 

  * It shows `unsupported` when trying to install
  * Waits for confirmation before executing the actual `yum` command
  * Allows confirmation to be overwritten by using `-y` in the command

Note:
Banner might need to be more prominent...
