### PR TITLE
Issue #231 add dnsmasq as fallback option

### DIFF
--- a/centos-7.template
+++ b/centos-7.template
@@ -48,6 +48,7 @@ fuse-sshfs
 nfs-utils
 go-hvkvp
 python-setuptools
+dnsmasq
 
 #Packages to be removed
 -aic94xx-firmware
@@ -182,6 +183,7 @@ systemctl disable network
 systemctl disable NetworkManager
 systemctl disable NetworkManager-dispatcher
 systemctl disable NetworkManager-wait-online
+systemctl disable dnsmasq
 systemctl enable minishift-handle-user-data
 systemctl enable minishift-set-ipaddress
 systemctl enable docker

--- a/rhel-7.template
+++ b/rhel-7.template
@@ -46,6 +46,7 @@ fuse-sshfs
 nfs-utils
 go-hvkvp
 python-setuptools
+dnsmasq
 
 #Packages to be removed
 -aic94xx-firmware
@@ -194,6 +195,7 @@ systemctl disable network
 systemctl disable NetworkManager
 systemctl disable NetworkManager-dispatcher
 systemctl disable NetworkManager-wait-online
+systemctl disable dnsmasq
 systemctl enable minishift-handle-user-data
 systemctl enable minishift-set-ipaddress
 systemctl enable docker


### PR DESCRIPTION
... when containerized deployment is not available or not wished for.

Service is disable on start, as Minishift handles the lifecycle.

Note: needed for https://github.com/minishift/minishift/issues/201