### PR TITLE
FIX: restore host keys after restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ BUILD_DIR=$(shell pwd)/build
 BIN_DIR=$(BUILD_DIR)/bin
 HANDLE_USER_DATA=$(shell base64 -w 0 scripts/handle-user-data)
 HANDLE_USER_DATA_SERVICE=$(shell base64 -w 0 scripts/handle-user-data.service)
+HANDLE_HOST_KEYS=$(shell base64 -w 0 scripts/handle-host-keys)
+HANDLE_HOST_KEYS_SERVICE=$(shell base64 -w 0 scripts/handle-host-keys.service)
 YUM_WRAPPER=$(shell base64 -w 0 scripts/yum-wrapper)
 CERT_GEN=$(shell base64 -w 0 scripts/cert-gen)
 SET_IPADDRESS=$(shell base64 -w 0 scripts/set-ipaddress)
@@ -68,6 +70,7 @@ rhel_kickstart: kickstart
 .PHONY: kickstart
 kickstart: init
 	@handle_user_data='$(HANDLE_USER_DATA)' handle_user_data_service='$(HANDLE_USER_DATA_SERVICE)' \
+	    handle_host_keys='$(HANDLE_HOST_KEYS)' handle_host_keys_service='$(HANDLE_HOST_KEYS_SERVICE)' \
         set_ipaddress='$(SET_IPADDRESS)' set_ipaddress_service='$(SET_IPADDRESS_SERVICE)' \
         yum_wrapper='$(YUM_WRAPPER)' cert_gen='$(CERT_GEN)' \
 		version='$(VERSION)' build_id='$(GITTAG)-$(TODAY)-$(BUILD_ID)' \

--- a/centos-7.template
+++ b/centos-7.template
@@ -162,6 +162,22 @@ base64 -d < handle-user-data-service.base64 > handle-user-data.service
 rm handle-user-data-service.base64
 mv handle-user-data.service /usr/lib/systemd/system/minishift-handle-user-data.service
 
+# Place holder for base64 encode handle-host-keys script
+cat > handle-host-keys.base64 << EOF
+${handle_host_keys}
+EOF
+base64 -d < handle-host-keys.base64 > handle-host-keys
+rm -f handle-host-keys.base64
+chmod +x handle-host-keys
+mv handle-host-keys /usr/local/bin/minishift-handle-host-keys
+
+# Handle host keys (systemd service)
+cat > handle-host-keys-service.base64 << EOF
+${handle_host_keys_service}
+EOF
+base64 -d < handle-host-keys-service.base64 > handle-host-keys.service
+rm handle-host-keys-service.base64
+mv handle-host-keys.service /usr/lib/systemd/system/minishift-handle-host-keys.service
 
 # Set IP address based on settings or hvkvp (Hyper-V)
 cat > set-ipaddress.base64 << EOF
@@ -190,6 +206,7 @@ systemctl disable NetworkManager-dispatcher
 systemctl disable NetworkManager-wait-online
 systemctl disable dnsmasq
 systemctl enable minishift-handle-user-data
+systemctl enable minishift-handle-host-keys
 systemctl enable minishift-set-ipaddress
 systemctl enable docker
 

--- a/rhel-7.template
+++ b/rhel-7.template
@@ -162,6 +162,22 @@ base64 -d < handle-user-data-service.base64 > handle-user-data.service
 rm handle-user-data-service.base64
 mv handle-user-data.service /usr/lib/systemd/system/minishift-handle-user-data.service
 
+# Place holder for base64 encode handle-host-keys script
+cat > handle-host-keys.base64 << EOF
+${handle_host_keys}
+EOF
+base64 -d < handle-host-keys.base64 > handle-host-keys
+rm -f handle-host-keys.base64
+chmod +x handle-host-keys
+mv handle-host-keys /usr/local/bin/minishift-handle-host-keys
+
+# Handle host keys (systemd service)
+cat > handle-host-keys-service.base64 << EOF
+${handle_host_keys_service}
+EOF
+base64 -d < handle-host-keys-service.base64 > handle-host-keys.service
+rm handle-host-keys-service.base64
+mv handle-host-keys.service /usr/lib/systemd/system/minishift-handle-host-keys.service
 
 # Set IP address based on settings or hvkvp (Hyper-V)
 cat > set-ipaddress.base64 << EOF
@@ -190,6 +206,7 @@ systemctl disable NetworkManager-dispatcher
 systemctl disable NetworkManager-wait-online
 systemctl disable dnsmasq
 systemctl enable minishift-handle-user-data
+systemctl enable minishift-handle-host-keys
 systemctl enable minishift-set-ipaddress
 systemctl enable docker
 systemctl enable rhel-push-plugin

--- a/scripts/handle-host-keys
+++ b/scripts/handle-host-keys
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+LABEL=b2d-data
+MAGIC="boot2docker, please format-me"
+UNPARTITIONED_HD="/dev/$(lsblk | grep disk | grep ".*da" | cut -f1 -d' ')"
+
+# Function to extract userdata.tar containing the ssh keys into the home directory /home/docker
+handle_host_keys() {
+    # Restore host ssh keys to avoid problems with external unknown_hosts configurations.
+    PARTNAME=`echo "$BOOT2DOCKER_DATA" | sed 's/.*\///'`
+    if [ -e "/mnt/$PARTNAME/etc/ssh" ]; then
+	    # Restore initial ssh keys
+        cp /mnt/$PARTNAME/etc/ssh/* /etc/ssh
+    else
+        # Save initial ssh keys	    
+        mkdir -p /mnt/$PARTNAME/etc/ssh
+        cp /etc/ssh/*key* /mnt/$PARTNAME/etc/ssh
+    fi
+}
+
+# TODO Need to make sure to have /sbin on the PATH. Is there a better way?
+# http://stackoverflow.com/questions/19983710/some-commands-not-wroking-on-remote-servers-through-ssh-shell
+# https://github.com/LalatenduMohanty/centos-live-iso/issues/11
+echo 'PATH=$PATH:/sbin' >> /home/docker/.bashrc
+
+# If there is a partition with `boot2docker-data` as its label we are dealing with
+# an already bootstrapped docker-machine. Just make sure to mount data partition and to unpack
+# userdata.tar. Remember, /home/docker is not persistent
+BOOT2DOCKER_DATA=`blkid -o device -l -t LABEL=$LABEL`
+if [ -n "$BOOT2DOCKER_DATA" ]; then
+    handle_host_keys
+    exit 0
+fi
+
+# Test for our magic string (it means that the disk was made by ./boot2docker init)
+HEADER=`dd if=$UNPARTITIONED_HD bs=1 count=${#MAGIC} 2>/dev/null`
+if [ "$HEADER" = "$MAGIC" ]; then
+    # Read /userdata.tar with ssh keys and place it temporarily under /
+    dd if=$UNPARTITIONED_HD of=/userdata.tar bs=1 count=4096 2>/dev/null
+
+    handle_host_keys
+    exit 0
+fi

--- a/scripts/handle-host-keys.service
+++ b/scripts/handle-host-keys.service
@@ -1,0 +1,16 @@
+#  This file is part of Minishift
+
+[Unit]
+Description=Minishift handle host keys
+ConditionFileIsExecutable=/usr/local/bin/minishift-handle-host-keys
+After=minishift-handle-user-data.service
+Before=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/minishift-handle-host-keys
+TimeoutSec=0
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Currently because of the livecd rootfs the host keys are lost. After a restart the host gets new keys. This causes problems with e.g. ssh which stores the public keys in known_hosts. Instead of messing around with ssh config it is easier to just restore the keys in case the machine was not newly created.

To keep this apart from user data I basically copied this to host-key handling.